### PR TITLE
Fix message type routing bug

### DIFF
--- a/lib/knode.js
+++ b/lib/knode.js
@@ -55,14 +55,31 @@ exports.KNode.prototype._onMessage = function(message) {
     if (!message.type || typeof message.type !== 'string')
         return;
 
-    var methodName = '_on' + _.str.titleize(_.str.camelize(message.type.toLowerCase()));
-    var action = this[methodName];
-    if (action) {
-        this._updateContact(MC(message));
-        _.bind(action, this)(message);
+    let action = null;
+    switch (message.type) {
+        case 'PING':
+            action = this._onPing();
+            break;
+
+        case 'FIND_NODE':
+            action = this._onFindNode();
+            break;
+
+        case 'FIND_VALUE':
+            action = this._onFindValue();
+            break;
+
+        case 'STORE':
+            action = this._onStore();
+            break;
+
+        default:
+            console.warn('Unknown message', message);
+            return;
     }
-    else
-        console.warn("Unknown message", message);
+
+    this._updateContact(MC(message));
+    _.bind(action, this)(message);
 }
 
 exports.KNode.prototype._onPing = function(message) {


### PR DESCRIPTION
The `_onMesage` function was doing some strange string manipulation to find the right handler. However, it was not able to find any function because of a function name casing problem. So I fix the bug a switch case that match and call the right function.